### PR TITLE
Modified Runtime to 8.10

### DIFF
--- a/templates/datastreaming.template
+++ b/templates/datastreaming.template
@@ -253,7 +253,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Handler: ctrprocessor.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       Description: Amazon Connect CTR Processor
       MemorySize: 128
       Timeout: 30
@@ -375,7 +375,7 @@ Resources:
     DependsOn: RedshiftCluster
     Properties:
       Handler: tblcreate.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       Description: Amazon Connect Table Creator for Redshift
       MemorySize: 128
       Timeout: 60


### PR DESCRIPTION
*Issue #, if available:*
The runtime parameter of nodejs6.10 is no longer supported for creating or updating AWS Lambda functions.

*Description of changes:*
Modified the Runtime of Lambda functions to use nodejs8.10

Tested this Template in my account in the us-east-1 region

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
