### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/templates/datastreaming.template
+++ b/templates/datastreaming.template
@@ -253,7 +253,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Handler: ctrprocessor.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Description: Amazon Connect CTR Processor
       MemorySize: 128
       Timeout: 30
@@ -375,7 +375,7 @@ Resources:
     DependsOn: RedshiftCluster
     Properties:
       Handler: tblcreate.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Description: Amazon Connect Table Creator for Redshift
       MemorySize: 128
       Timeout: 60


### PR DESCRIPTION
CloudFormation templates in connect-integration-datastreaming have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.