### PR TITLE
Update ctrprocessor.js to resolve Buffer() security violation

### DIFF
--- a/functions/source/ctrprocessor/ctrprocessor.js
+++ b/functions/source/ctrprocessor/ctrprocessor.js
@@ -62,7 +62,7 @@ exports.handler = (event, context, callback) => {
         }
         const record = records[position];
 
-        const payload = new Buffer(record.kinesis.data, 'base64').toString('ascii');
+        const payload = new Buffer.from(record.kinesis.data, 'base64').toString('ascii');
         console.log('Decoded payload:', payload);
 
         const ctr = JSON.parse(payload);


### PR DESCRIPTION
Buffer() has been deprecated due to security.  Needed to add Buffer.from() to make this code work

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
